### PR TITLE
Fix fat jar executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .gradle
 .idea
+*.iml
 .classpath
 .mvn
 .project

--- a/vertx-starter-generator/src/main/resources/templates/pom.xml.hbs
+++ b/vertx-starter-generator/src/main/resources/templates/pom.xml.hbs
@@ -45,6 +45,7 @@
                               </transformer>
                               <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                   <resource>META-INF/services/io.vertx.core.spi.VerticleFactory</resource>
+                                  <resource>META-INF/services/io.vertx.core.spi.launcher.CommandFactory</resource>
                               </transformer>
                           </transformers>
                           <artifactSet>


### PR DESCRIPTION
Adds CommandFactory to maven shade AppendingTransformer which solves the issue of the fat jar not being executable.

Possibly fixes https://github.com/vert-x3/vertx-starter/issues/44 also  

Also added *.iml files to .gitignore to reduce the noise when developing with IntelliJ