### PR TITLE
Add versions 3.5.1, 3.5.2 and 3.5.3

### DIFF
--- a/vertx-starter-main/conf/default-conf.json
+++ b/vertx-starter-main/conf/default-conf.json
@@ -2,7 +2,7 @@
   "web": {
     "http.port": 7070,
     "project.request": {
-      "version": "3.5.0",
+      "version": "3.5.3",
       "format": "zip",
       "language": "java",
       "build": "maven",

--- a/vertx-starter-web/src/main/java/io/vertx/starter/web/service/VersionService.java
+++ b/vertx-starter-web/src/main/java/io/vertx/starter/web/service/VersionService.java
@@ -23,6 +23,9 @@ import io.vertx.core.json.JsonArray;
 public class VersionService {
 
   public static final JsonArray VERSIONS = new JsonArray()
+    .add("3.5.3")
+    .add("3.5.2")
+    .add("3.5.1")
     .add("3.5.0")
     .add("3.4.2")
     .add("3.4.1")

--- a/vertx-starter-web/src/test/java/io/vertx/starter/web/rest/VersionResourceIntTest.java
+++ b/vertx-starter-web/src/test/java/io/vertx/starter/web/rest/VersionResourceIntTest.java
@@ -21,7 +21,7 @@ public class VersionResourceIntTest extends AbstractResourceIntTest {
       if (response.succeeded()) {
         assertThat(response.result().statusCode(), is(200));
         JsonArray payload = response.result().body();
-        assertThat(payload.size(), is(4));
+        assertThat(payload.size(), is(7));
         async.complete();
       } else {
         context.fail(response.cause());


### PR DESCRIPTION
Adding vert.x versions 3.5.1 and 3.5.2 and setting the later as the default option.