### PR TITLE
Select dependencies panel

### DIFF
--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -156,6 +156,11 @@
     .btn-advanced:active, .btn-advanced:focus {
       outline: none;
     }
+
+    .modal-backdrop
+    {
+      opacity:0.5 !important;
+    }
   </style>
 </head>
 <body ng-app="app">
@@ -230,7 +235,10 @@
           </div>
         </div>
         <div class="form-group row">
-          <label for="dependencies" class="col-sm-4 col-form-label">Dependencies</label>
+          <label for="dependencies" class="col-sm-4 col-form-label">
+            Dependencies
+            <button type="button" class="btn btn-link" ng-click="vm.openVertxDependenciesModal()">See all</button>
+          </label>
           <div class="col-sm-8">
             <input type="text" id="dependencies" class="form-control" placeholder="Web, MQTT, etc."
                    ng-model="vm.selectedDependency"
@@ -284,6 +292,33 @@
         </div>
       </div>
     </div>
+    <script type="text/ng-template" id="vertxDependenciesModal.html">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close" ng-click="vm.cancel()"><i class="fa fa-close"></i></button>
+        <h3 class="modal-title" id="modal-title">Dependencies for Vert.x </h3>
+      </div>
+      <div class="modal-body" id="modal-body">
+        <ul>
+          <li ng-repeat="it in vm.vertxDependencies">
+            <h3>{{ it.category }}</h3>
+          <ul>
+            <li ng-repeat="item in it.items">
+              <label>
+                <input type="checkbox"
+                       ng-checked="vm.indexOfDependencyArtifactId(item.artifactId) > -1"
+                       value="{{item}}"
+                       ng-click="vm.toggleDependency(item)"> {{ item.name }}
+              </label>
+            </li>
+          </ul>
+          </li>
+        </ul>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-primary" type="button" ng-click="vm.apply()">Apply</button>
+        <button class="btn btn-warning" type="button" ng-click="vm.cancel()">Cancel</button>
+      </div>
+    </script>
     <div class="row">
       <div uib-alert ng-repeat="alert in vm.alerts track by $index" class="alert-danger" close="vm.closeAlert($index)">
         <p>


### PR DESCRIPTION
Fix #97

I finally implemented it with a modal. 
<img width="1440" alt="Capture d’écran 2019-04-12 à 15 28 22" src="https://user-images.githubusercontent.com/593564/56019595-a7203100-5d37-11e9-9414-6de09a55c414.png">
<img width="1440" alt="Capture d’écran 2019-04-12 à 15 28 27" src="https://user-images.githubusercontent.com/593564/56019594-a6879a80-5d37-11e9-8a87-c1b165378dba.png">

The dependencies lists on the main window and in the modal are synced together. There is still a graphical effort to do but the JS piping is done.
@jponge artist spirit is welcome 😉 
