### PR TITLE
Follows up on 3.8 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Simply click on _Generate Project_ on the web interface to download a project ar
 If you are a CLI adept, you can use any http client (curl, [httpie](https://httpie.org/)) to invoke the API.
 
 ```
-$ curl -X GET http://start.vertx.io/starter.zip -d groupId=com.acme -d language=java -d vertxVersion=3.7.1 -o starter.zip
+$ curl -X GET http://start.vertx.io/starter.zip -d groupId=com.acme -d language=java -d vertxVersion=3.8.0 -o starter.zip
 ```
 
 ## API
@@ -38,7 +38,7 @@ Full example:
 
 ```
 curl -X GET \
-  'http://start.vertx.io/starter.zip?artifactId=starter&buildTool=maven&groupId=io.vertx&language=java&vertxDependencies=&vertxVersion=3.7.1' \
+  'http://start.vertx.io/starter.zip?artifactId=starter&buildTool=maven&groupId=io.vertx&language=java&vertxDependencies=&vertxVersion=3.8.0' \
   -o starter.zip
 ```
 
@@ -50,7 +50,7 @@ groupId==io.vertx \
 artitfactId==starter \
 language==java \
 buildTool==maven \
-vertxVersion==3.7.1 \
+vertxVersion==3.8.0 \
 vertxDependencies==vertx-web,vertx-web-client \
 -o starter.zip
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
 }
 
 vertx {
-  vertxVersion = "3.7.1"
+  vertxVersion = "3.8.0"
   mainVerticle = "io.github.jponge.vertx.boot.BootVerticle"
   jvmArgs = listOf("-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory")
 }

--- a/src/main/java/io/vertx/starter/AnalyticsVerticle.java
+++ b/src/main/java/io/vertx/starter/AnalyticsVerticle.java
@@ -17,7 +17,7 @@
 package io.vertx.starter;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.ext.mongo.MongoClient;
 import io.vertx.starter.config.Topics;
 import io.vertx.starter.model.VertxProject;
@@ -34,7 +34,7 @@ public class AnalyticsVerticle extends AbstractVerticle {
   }
 
   @Override
-  public void start(Future<Void> startFuture) {
+  public void start(Promise<Void> startPromise) {
     AnalyticsService analyticsService = new AnalyticsService(mongoClient());
     vertx.eventBus().<VertxProject>consumer(Topics.PROJECT_CREATED).handler(analyticsService::onProjectCreated);
 
@@ -45,6 +45,6 @@ public class AnalyticsVerticle extends AbstractVerticle {
       AnalyticsVerticle.class.getSimpleName()
     );
 
-    startFuture.complete();
+    startPromise.complete();
   }
 }

--- a/src/main/java/io/vertx/starter/GenerationHandler.java
+++ b/src/main/java/io/vertx/starter/GenerationHandler.java
@@ -38,7 +38,7 @@ public class GenerationHandler implements Handler<RoutingContext> {
   public void handle(RoutingContext rc) {
     VertxProject project = rc.get(WebVerticle.VERTX_PROJECT_KEY);
 
-    rc.vertx().eventBus().<Buffer>send(PROJECT_REQUESTED, project, reply -> {
+    rc.vertx().eventBus().<Buffer>request(PROJECT_REQUESTED, project, reply -> {
       if (reply.succeeded()) {
 
         rc.vertx().eventBus().publish(PROJECT_CREATED, project);

--- a/src/main/java/io/vertx/starter/GeneratorVerticle.java
+++ b/src/main/java/io/vertx/starter/GeneratorVerticle.java
@@ -17,7 +17,7 @@
 package io.vertx.starter;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.starter.config.Topics;
@@ -40,7 +40,7 @@ public class GeneratorVerticle extends AbstractVerticle {
   private GeneratorService generatorService;
 
   @Override
-  public void start(Future<Void> startFuture) {
+  public void start(Promise<Void> startPromise) {
     vertx.fileSystem().readFile("keywords", kar -> {
       if (kar.succeeded()) {
 
@@ -62,15 +62,15 @@ public class GeneratorVerticle extends AbstractVerticle {
               GeneratorVerticle.class.getSimpleName()
             );
 
-            startFuture.complete();
+            startPromise.complete();
 
           } else {
-            startFuture.fail(ar.cause());
+            startPromise.fail(ar.cause());
           }
         });
 
       } else {
-        startFuture.fail(kar.cause());
+        startPromise.fail(kar.cause());
       }
     });
   }

--- a/src/main/java/io/vertx/starter/WebVerticle.java
+++ b/src/main/java/io/vertx/starter/WebVerticle.java
@@ -17,7 +17,7 @@
 package io.vertx.starter;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
@@ -68,7 +68,7 @@ public class WebVerticle extends AbstractVerticle {
   }
 
   @Override
-  public void start(Future<Void> startFuture) {
+  public void start(Promise<Void> startPromise) {
     vertx.eventBus().registerDefaultCodec(VertxProject.class, new VertxProjectCodec());
 
     Router router = Router.router(vertx);
@@ -93,14 +93,14 @@ public class WebVerticle extends AbstractVerticle {
       .listen(port, ar -> {
         if (ar.failed()) {
           log.error("Fail to start {}", WebVerticle.class.getSimpleName(), ar.cause());
-          startFuture.fail(ar.cause());
+          startPromise.fail(ar.cause());
         } else {
           log.info("\n----------------------------------------------------------\n\t" +
               "{} is running! Access URLs:\n\t" +
               "Local: \t\thttp://localhost:{}\n" +
               "----------------------------------------------------------",
             WebVerticle.class.getSimpleName(), port);
-          startFuture.complete();
+          startPromise.complete();
         }
       });
   }

--- a/src/main/resources/starter.json
+++ b/src/main/resources/starter.json
@@ -4,21 +4,27 @@
     "artifactId": "starter",
     "language": "java",
     "buildTool": "maven",
-    "vertxVersion": "3.7.1",
+    "vertxVersion": "3.8.0",
     "archiveFormat": "zip",
     "jdkVersion": "1.8"
   },
   "versions": [
     {
-      "number": "3.7.1",
+      "number": "3.8.0",
       "exclusions": []
     },
     {
-      "number": "3.6.3",
+      "number": "3.7.1",
       "exclusions": [
         "vertx-web-graphql",
-        "vertx-amqp-client"
+        "vertx-amqp-client",
+        "vertx-pg-client",
+        "vertx-mysql-client"
       ]
+    },
+    {
+      "number": "4.0.0-milestone1",
+      "exclusions": []
     },
     {
       "number": "4.0.0-SNAPSHOT",
@@ -55,6 +61,14 @@
       "category": "Data Access",
       "description": "Vert.x provides a few different asynchronous clients for accessing various data stores from your application. You don't have to use these clients - you could use clients direct from the vendor if you prefer (e.g. MongoDB provide their own cool async and reactive clients), but these provide a simple async API which is available in various languages.",
       "items": [
+        {
+          "artifactId": "vertx-pg-client",
+          "name": "Reactive PostgreSQL client"
+        },
+        {
+          "artifactId": "vertx-mysql-client",
+          "name": "Reactive MySQL client"
+        },
         {
           "artifactId": "vertx-mongo-client",
           "name": "MongoDB client"


### PR DESCRIPTION
- new version set: _3.8.0, 3.7.1, 4.0.0-milestone1, 4.0.0-SNAPSHOT_
- upgrade to 3.8 (`Future`/`Promise` and `send`/`request`)