### PR TITLE
Generate start method with Promise argument

### DIFF
--- a/src/main/resources/templates/src/main/java/MainVerticle.java.ftl
+++ b/src/main/resources/templates/src/main/java/MainVerticle.java.ftl
@@ -1,7 +1,7 @@
 package ${packageName};
 
 import io.vertx.core.AbstractVerticle;
-<#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8")>
+<#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8") && !vertxVersion?starts_with("3.9")>
 import io.vertx.core.Future;
 <#else>
 import io.vertx.core.Promise;
@@ -10,7 +10,7 @@ import io.vertx.core.Promise;
 public class MainVerticle extends AbstractVerticle {
 
   @Override
-  <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8")>
+  <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8") && !vertxVersion?starts_with("3.9")>
   public void start(Future<Void> startFuture) throws Exception {
   <#else>
   public void start(Promise<Void> startPromise) throws Exception {
@@ -21,14 +21,14 @@ public class MainVerticle extends AbstractVerticle {
         .end("Hello from Vert.x!");
     }).listen(8888, http -> {
       if (http.succeeded()) {
-    <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8")>
+    <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8") && !vertxVersion?starts_with("3.9")>
         startFuture.complete();
     <#else>
         startPromise.complete();
     </#if>
         System.out.println("HTTP server started on port 8888");
       } else {
-    <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8")>
+    <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8") && !vertxVersion?starts_with("3.9")>
         startFuture.fail(http.cause());
     <#else>
         startPromise.fail(http.cause());

--- a/src/main/resources/templates/src/main/kotlin/MainVerticle.kt.ftl
+++ b/src/main/resources/templates/src/main/kotlin/MainVerticle.kt.ftl
@@ -1,7 +1,7 @@
 package ${packageName}
 
 import io.vertx.core.AbstractVerticle
-<#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8")>
+<#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8") && !vertxVersion?starts_with("3.9")>
 import io.vertx.core.Future
 <#else>
 import io.vertx.core.Promise
@@ -9,7 +9,7 @@ import io.vertx.core.Promise
 
 class MainVerticle : AbstractVerticle() {
 
-  <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8")>
+  <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8") && !vertxVersion?starts_with("3.9")>
   override fun start(startFuture: Future<Void>) {
   <#else>
   override fun start(startPromise: Promise<Void>) {
@@ -23,14 +23,14 @@ class MainVerticle : AbstractVerticle() {
       }
       .listen(8888) { http ->
         if (http.succeeded()) {
-      <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8")>
+      <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8") && !vertxVersion?starts_with("3.9")>
           startFuture.complete()
       <#else>
           startPromise.complete()
       </#if>
           println("HTTP server started on port 8888")
         } else {
-      <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8")>
+      <#if vertxVersion?starts_with("3") && !vertxVersion?starts_with("3.8") && !vertxVersion?starts_with("3.9")>
           startFuture.fail(http.cause());
       <#else>
           startPromise.fail(http.cause());


### PR DESCRIPTION
Motivation:

I generated a new vertx application using the starter and  I remarked that generating a new project using version 3.9.0 generates a MainVerticle with a start method expecting a deprecated Future argument instead of a Promise. This PR attempts to fix it.
