### PR TITLE
Use mainClass instead of mainClassName

### DIFF
--- a/src/main/resources/templates/build.gradle.kts.ftl
+++ b/src/main/resources/templates/build.gradle.kts.ftl
@@ -44,7 +44,7 @@ val doOnChange = "${projectDir}/gradlew classes"
 </#noparse>
 
 application {
-  mainClassName = launcherClassName
+  mainClass.set(launcherClassName)
 }
 
 dependencies {


### PR DESCRIPTION
Motivation:

This PR is a migration from mainClassName to mainClass. It seems to be deprecated in the java plugin and it says one should use mainClass instead.

https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaApplication.java#L73

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
