### PR TITLE
New modules in Vert.x 4.1

### DIFF
--- a/src/main/resources/starter.json
+++ b/src/main/resources/starter.json
@@ -33,7 +33,7 @@
       "exclusions": []
     },
     {
-      "number": "4.0.4-SNAPSHOT",
+      "number": "4.1.0-SNAPSHOT",
       "exclusions": []
     }
   ],

--- a/src/main/resources/starter.json
+++ b/src/main/resources/starter.json
@@ -351,8 +351,8 @@
       ]
     },
     {
-      "code": "devops",
-      "category": "DevOps",
+      "code": "monitoring",
+      "category": "Monitoring",
       "description": "Vert.x offers various component to keep your Vert.x application on track when running in production",
       "items": [
         {
@@ -369,11 +369,6 @@
           "artifactId": "vertx-health-check",
           "name": "Vert.x Health Check",
           "description": "This component provides a simple way to expose health checks."
-        },
-        {
-          "artifactId": "vertx-shell",
-          "name": "Shell",
-          "description": "This component lets you interact with your Vert.x application using a CLI interface."
         }
       ]
     },
@@ -464,6 +459,17 @@
           "artifactId": "vertx-json-schema",
           "name": "JSON Schema",
           "description": "An extensible implementation of the Json Schema specification to validate every JSON data structure, asynchronously."
+        }
+      ]
+    },
+    {
+      "code": "devops",
+      "category": "Devops",
+      "items": [
+        {
+          "artifactId": "vertx-shell",
+          "name": "Shell",
+          "description": "This component lets you interact with your Vert.x application using a CLI interface."
         }
       ]
     }

--- a/src/main/resources/starter.json
+++ b/src/main/resources/starter.json
@@ -22,15 +22,20 @@
         "vertx-web-templ-httl",
         "vertx-web-sstore-cookie",
         "vertx-web-sstore-redis",
+        "vertx-web-sstore-infinispan",
         "vertx-json-schema",
         "vertx-web-validation",
         "vertx-web-openapi",
-        "vertx-sql-client-templates"
+        "vertx-sql-client-templates",
+        "vertx-opentelemetry"
       ]
     },
     {
       "number": "4.0.3",
-      "exclusions": []
+      "exclusions": [
+        "vertx-web-sstore-infinispan",
+        "vertx-opentelemetry"
+      ]
     },
     {
       "number": "4.1.0-SNAPSHOT",
@@ -101,6 +106,10 @@
         {
           "artifactId": "vertx-web-sstore-redis",
           "name": "Redis session storage"
+        },
+        {
+          "artifactId": "vertx-web-sstore-infinispan",
+          "name": "Session storage with Infinispan Client"
         },
         {
           "artifactId": "vertx-web-validation",
@@ -369,6 +378,11 @@
           "artifactId": "vertx-health-check",
           "name": "Vert.x Health Check",
           "description": "This component provides a simple way to expose health checks."
+        },
+        {
+          "artifactId": "vertx-opentelemetry",
+          "name": "Tracing using OpenTelemetry",
+          "description": "Distributed tracing with OpenTelemetry."
         }
       ]
     },

--- a/src/main/resources/starter.json
+++ b/src/main/resources/starter.json
@@ -27,6 +27,8 @@
         "vertx-web-validation",
         "vertx-web-openapi",
         "vertx-sql-client-templates",
+        "vertx-zipkin",
+        "vertx-opentracing",
         "vertx-opentelemetry"
       ]
     },
@@ -378,6 +380,16 @@
           "artifactId": "vertx-health-check",
           "name": "Vert.x Health Check",
           "description": "This component provides a simple way to expose health checks."
+        },
+        {
+          "artifactId": "vertx-zipkin",
+          "name": "Zipkin",
+          "description": "Distributed tracing with Zipkin."
+        },
+        {
+          "artifactId": "vertx-opentracing",
+          "name": "OpenTracing",
+          "description": "Distributed tracing with OpenTracing."
         },
         {
           "artifactId": "vertx-opentelemetry",


### PR DESCRIPTION
- Switch to 4.1.0-SNAPSHOT
- Split monitoring and devops categories
- Added Zipkin and OpenTracing (missing)
- New in 4.1: Infinispan Session Store and OpenTelemetry
