### PR TITLE
fix build.gradle.kts: url in maven repository

### DIFF
--- a/src/main/resources/templates/build.gradle.kts.ftl
+++ b/src/main/resources/templates/build.gradle.kts.ftl
@@ -20,7 +20,7 @@ version = "1.0.0-SNAPSHOT"
 repositories {
 <#if vertxVersion?ends_with("-SNAPSHOT")>
   maven {
-    url "https://s01.oss.sonatype.org/content/repositories/snapshots"
+    url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots")
     mavenContent {
       snapshotsOnly()
     }


### PR DESCRIPTION
Signed-off-by: Olga Ivanova <olga.a.ivanova@inbox.ru>

Motivation:

Fix declaration of repository url in build.gradle.kts.
