### PR TITLE
ditch jcenter for new projects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 repositories {
-  jcenter()
+  mavenCentral()
   mavenLocal()
 }
 

--- a/src/main/resources/templates/build.gradle.kts.ftl
+++ b/src/main/resources/templates/build.gradle.kts.ftl
@@ -27,9 +27,6 @@ repositories {
   }
 </#if>
   mavenCentral()
-<#if language == "kotlin">
-  jcenter()
-</#if>
 }
 
 val vertxVersion = "${vertxVersion}"


### PR DESCRIPTION
Signed-off-by: Selim Dincer <wowselim@live.de>

Motivation:

This PR removes two references to jcenter as described in https://github.com/vert-x3/vertx-starter/issues/182. It leaves jcenter as repo for the build script of this repo itself but new projects won't include a reference to jcenter any longer.
