### PR TITLE
Bump kotlin to 1.5.0

### DIFF
--- a/src/main/resources/templates/build.gradle.kts.ftl
+++ b/src/main/resources/templates/build.gradle.kts.ftl
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
 <#if language == "kotlin">
-  kotlin ("jvm") version "1.4.21"
+  kotlin ("jvm") version "1.5.0"
 <#else>
   java
 </#if>

--- a/src/main/resources/templates/pom.xml.ftl
+++ b/src/main/resources/templates/pom.xml.ftl
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 <#if language == "kotlin">
-    <kotlin.version>1.4.21</kotlin.version>
+    <kotlin.version>1.5.0</kotlin.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 
 <#else>


### PR DESCRIPTION
Motivation:

This PR bumps the kotlin version to 1.5.0 to make projects work with gradle 7.