### PR TITLE
Add Vert.x core dependency if version is 4.4.0

### DIFF
--- a/src/main/resources/templates/build.gradle.kts.ftl
+++ b/src/main/resources/templates/build.gradle.kts.ftl
@@ -46,7 +46,7 @@ application {
 
 dependencies {
   implementation(platform("io.vertx:vertx-stack-depchain:$vertxVersion"))
-<#if !vertxDependencies?has_content>
+<#if !vertxDependencies?has_content || vertxVersion == "4.4.0">
   implementation("io.vertx:vertx-core")
 </#if>
 <#list vertxDependencies as dependency>

--- a/src/main/resources/templates/pom.xml.ftl
+++ b/src/main/resources/templates/pom.xml.ftl
@@ -50,7 +50,7 @@
   </dependencyManagement>
 
   <dependencies>
-<#if !vertxDependencies?has_content>
+<#if !vertxDependencies?has_content || vertxVersion == "4.4.0">
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>


### PR DESCRIPTION
Otherwise, Kotlin only projects cannot compile because of https://github.com/vert-x3/vertx-lang-kotlin/issues/230