### PR TITLE
Add Scala support

### DIFF
--- a/src/main/java/io/vertx/starter/model/Language.java
+++ b/src/main/java/io/vertx/starter/model/Language.java
@@ -25,7 +25,10 @@ public enum Language {
   JAVA("java", ".java"),
 
   @JsonProperty("kotlin")
-  KOTLIN("kotlin", ".kt", "vertx-lang-kotlin");
+  KOTLIN("kotlin", ".kt", "vertx-lang-kotlin"),
+
+  @JsonProperty("scala")
+  SCALA("scala", ".scala");
 
   private final String name;
   private final String extension;

--- a/src/main/resources/templates/build.gradle.kts.ftl
+++ b/src/main/resources/templates/build.gradle.kts.ftl
@@ -7,6 +7,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
 <#if language == "kotlin">
   kotlin ("jvm") version "1.7.21"
+<#elseif language == "scala">
+  scala
 <#else>
   java
 </#if>
@@ -54,11 +56,18 @@ dependencies {
 </#list>
 <#if language == "kotlin">
   implementation(kotlin("stdlib-jdk8"))
+<#elseif language == "scala">
+  implementation("org.scala-lang:scala3-library_3:3.3.1")
+  implementation("io.vertx:vertx-lang-scala3:${vertxVersion}")
 </#if>
 <#if hasPgClient>
   implementation("com.ongres.scram:client:2.1")
 </#if>
-<#if hasVertxJUnit5>
+<#if language == "scala">
+  testImplementation("io.vertx:vertx-lang-scala3-test:${vertxVersion}")
+  testImplementation("org.scalatest:scalatest_3:3.2.17")
+  testRuntimeOnly("org.scalatestplus:junit-5-10_3:3.2.17.0")
+<#elseif hasVertxJUnit5>
   testImplementation("io.vertx:vertx-junit5")
   testImplementation("org.junit.jupiter:junit-jupiter:$junitJupiterVersion")
 <#elseif hasVertxUnit>

--- a/src/main/resources/templates/pom.xml.ftl
+++ b/src/main/resources/templates/pom.xml.ftl
@@ -13,7 +13,8 @@
 
 <#if language == "kotlin">
     <kotlin.version>1.7.21</kotlin.version>
-
+<#elseif language == "scala">
+    <scala.version>3.3.1</scala.version>
 <#else>
 <#if jdkVersion == "1.8">
     <maven.compiler.source>${jdkVersion}</maven.compiler.source>
@@ -70,6 +71,24 @@
       <version>${kotlin.version}</version>
     </dependency>
 </#noparse>
+<#elseif language == "scala">
+<#noparse>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala3-library_3</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-scala3</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-scala3-test</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+</#noparse>
 </#if>
 <#if hasPgClient>
     <dependency>
@@ -79,7 +98,14 @@
     </dependency>
 </#if>
 
-<#if hasVertxJUnit5>
+<#if language == "scala">
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_3</artifactId>
+      <version>3.2.17</version>
+      <scope>test</scope>
+    </dependency>
+<#elseif hasVertxJUnit5>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
@@ -122,6 +148,11 @@
       <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
       <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
 </#noparse>
+<#elseif language == "scala">
+<#noparse>
+      <sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>
+      <testSourceDirectory>${project.basedir}/src/test/scala</testSourceDirectory>
+</#noparse>
 </#if>
     <plugins>
 <#if language == "kotlin">
@@ -145,6 +176,53 @@
             <id>test-compile</id>
             <goals>
               <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+<#elseif language == "scala">
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>4.8.1</version>
+        <configuration>
+          <args>
+            <arg>java-output-version 8</arg>
+            <arg>-feature</arg>
+            <arg>-deprecation</arg>
+          </args>
+        </configuration>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <version>2.2.0</version>
+        <configuration>
+<#noparse>
+          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+</#noparse>
+          <junitxml>.</junitxml>
+          <filereports>WDF TestSuite.txt</filereports>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
             </goals>
           </execution>
         </executions>
@@ -199,6 +277,11 @@
 <#noparse>
         <version>${maven-surefire-plugin.version}</version>
 </#noparse>
+<#if language == "scala">
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+</#if>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/src/main/resources/templates/pom.xml.ftl
+++ b/src/main/resources/templates/pom.xml.ftl
@@ -83,11 +83,6 @@
       <artifactId>vertx-lang-scala3</artifactId>
       <version>${vertx.version}</version>
     </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-lang-scala3-test</artifactId>
-      <version>${vertx.version}</version>
-    </dependency>
 </#noparse>
 </#if>
 <#if hasPgClient>
@@ -99,6 +94,12 @@
 </#if>
 
 <#if language == "scala">
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-scala3-test</artifactId>
+      <version>${vertx.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_3</artifactId>

--- a/src/main/resources/templates/src/main/scala/MainVerticle.scala.ftl
+++ b/src/main/resources/templates/src/main/scala/MainVerticle.scala.ftl
@@ -1,0 +1,28 @@
+package ${packageName}
+
+import io.vertx.core.{AbstractVerticle, Promise}
+import io.vertx.lang.scala.ScalaVerticle
+import io.vertx.lang.scala.ImplicitConversions.vertxFutureToScalaFuture
+
+import scala.concurrent.Future
+import scala.language.implicitConversions
+
+class MainVerticle extends AbstractVerticle:
+
+  override def start(startPromise: Promise[Void]): Unit =
+    vertx
+      .deployVerticle(HttpVerticle().asJava)
+      .onSuccess(_ => startPromise.complete)
+      .onFailure(e => startPromise.fail(e))
+
+
+class HttpVerticle extends ScalaVerticle:
+
+  override def asyncStart: Future[Unit] =
+    vertx
+      .createHttpServer()
+      .requestHandler(_.response
+        .putHeader("content-type", "text/plain")
+        .end("Hello from Vert.x!"))
+      .listen(8888)
+      .mapEmpty[Unit]()

--- a/src/main/resources/templates/src/test/scala/TestMainVerticle.scala.ftl
+++ b/src/main/resources/templates/src/test/scala/TestMainVerticle.scala.ftl
@@ -1,0 +1,24 @@
+package ${packageName}
+
+import io.vertx.core.http.HttpMethod
+
+import io.vertx.lang.scala.ImplicitConversions.vertxFutureToScalaFuture
+import io.vertx.lang.scala.testing.VerticleTesting
+
+import org.scalatest.matchers.should.Matchers
+
+import scala.language.implicitConversions
+
+
+class HttpVerticleSpec extends VerticleTesting[HttpVerticle], Matchers:
+
+  "HttpVerticle" should "bind to 8888 and answer with 'Hello from Vert.x!'" in {
+    val httpClient = vertx.createHttpClient()
+
+    for {
+      req  <- httpClient.request(HttpMethod.GET, 8888, "127.0.0.1", "/")
+      res  <- req.send()
+      body <- res.body.map(_.toString)
+      assertion = body should equal("Hello from Vert.x!")
+    } yield assertion
+  }


### PR DESCRIPTION
Motivation:

Generating a project with the Scala language is currently not supported. This change adds Scala support with Maven and Gradle build systems.

Hint:

Before integrating this change, we need a release of [Vert.x Scala support ](https://github.com/vert-x3/vertx-lang-scala).

Closes #118 