### PR TITLE
Fix macos detection

### DIFF
--- a/src/main/frontend/src/components/GenerateButton.vue
+++ b/src/main/frontend/src/components/GenerateButton.vue
@@ -36,7 +36,7 @@ export default {
       return parsedResult.os.name.toLowerCase() === 'windows'
     },
     isMac() {
-      return parsedResult.os.name.toLowerCase() === 'macOS'
+      return parsedResult.os.name.toLowerCase() === 'macos'
     },
     hotkey() {
       return this.isMac ? '\u2318 + \u23CE' : 'alt + \u23CE'


### PR DESCRIPTION
Motivation:

GenerateButton will draw the cloverleaf icon on macOS with this change.

Conformance:

I've signed the Eclipse committer agreement.
