### PR TITLE
Improve vertx version upgrade

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,4 @@
 = Vertx.x Starter
-:vertx-version: 4.5.8
 
 image:https://github.com/vert-x3/vertx-starter/workflows/CI/badge.svg[Build Status,link=https://github.com/vert-x3/vertx-starter/actions?query=workflow%3ACI]
 
@@ -13,7 +12,10 @@ If you are a CLI adept, you can use any http client (curl, https://httpie.org/[h
 
 [source,shell,subs="attributes"]
 ----
-curl -X GET https://start.vertx.io/starter.zip -d groupId=com.acme -d language=java -d vertxVersion={vertx-version} -o starter.zip
+curl -G https://start.vertx.io/starter.zip \
+  -d "groupId=com.example" \
+  -d "language=java" \
+  --output starter.zip
 ----
 
 == API
@@ -40,21 +42,24 @@ Full example:
 
 [source,shell,subs="attributes"]
 ----
-curl -X GET \
-  'https://start.vertx.io/starter.zip?artifactId=starter&buildTool=maven&groupId=io.vertx&language=java&vertxDependencies=&vertxVersion={vertx-version}' \
-  -o starter.zip
+curl -G https://start.vertx.io/starter.zip \
+  -d "groupId=com.example" \
+  -d "artifactId=starter" \
+  -d "language=java" \
+  -d "buildTool=maven" \
+  -d "vertxDependencies=vertx-web,vertx-web-client"
+  --output starter.zip
 ----
 
 The HTTPie equivalent:
 
 [source,shell,subs="attributes"]
 ----
-$ http https://start.vertx.io/starter.zip \
-  groupId==io.vertx \
+http https://start.vertx.io/starter.zip \
+  groupId==com.example \
   artitfactId==starter \
   language==java \
   buildTool==maven \
-  vertxVersion=={vertx-version} \
   vertxDependencies==vertx-web,vertx-web-client \
   -o starter.zip
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
     <!-- vert.x properties -->
+    <!-- It is not required to update this property when a new Vert.x version is released -->
     <vertx.version>4.5.8</vertx.version>
     <vertx.verticle>io.vertx.starter.MainVerticle</vertx.verticle>
     <!-- Maven plugins -->

--- a/src/test/java/io/vertx/starter/service/GeneratorTest.java
+++ b/src/test/java/io/vertx/starter/service/GeneratorTest.java
@@ -57,7 +57,6 @@ import static io.vertx.starter.model.ArchiveFormat.TGZ;
 import static io.vertx.starter.model.BuildTool.GRADLE;
 import static io.vertx.starter.model.BuildTool.MAVEN;
 import static io.vertx.starter.model.JdkVersion.*;
-import static io.vertx.starter.model.Language.JAVA;
 import static io.vertx.starter.model.Language.KOTLIN;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -120,9 +119,6 @@ class GeneratorTest {
       .setId("demo")
       .setGroupId("com.example")
       .setArtifactId("demo")
-      .setLanguage(JAVA)
-      .setBuildTool(MAVEN)
-      .setVertxVersion("4.5.8")
       .setArchiveFormat(TGZ);
   }
 


### PR DESCRIPTION
Closes #475

With these changes, updating the starter.json file will be the only requirement when a new Vert.x version is released.