### PR TITLE
Set versions workflow

### DIFF
--- a/.github/workflows/set-versions.yml
+++ b/.github/workflows/set-versions.yml
@@ -1,0 +1,34 @@
+name: "Set versions"
+on:
+  workflow_dispatch:
+    inputs:
+      stableVersion:
+        description: 'Vert.x stable version, e.g 1.2.3'
+        required: true
+        type: string
+      stableSnapshotVersion:
+        description: 'Vert.x stable snapshot version, e.g. 1.2.4-SNAPSHOT'
+        required: true
+        type: string
+jobs:
+  set-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+      - uses: dcarbone/install-jq-action@v2
+        with:
+          version: '1.7'
+          force: true
+      - run: |
+          tmp=$(mktemp)
+          cat src/main/resources/starter.json | jq ".versions[0].number=\"$STABLE_VERSION\" | .versions[1].number=\"$STABLE_SNAPSHOT_VERSION\"" > "$tmp" && mv "$tmp" src/main/resources/starter.json
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add src/main/resources/starter.json
+          git commit -m "Update stable version to $STABLE_VERSION and stable snapshot version to $STABLE_SNAPSHOT_VERSION"
+          git push
+        env:
+          STABLE_VERSION: ${{ inputs.stableVersion }}
+          STABLE_SNAPSHOT_VERSION: ${{ inputs.stableSnapshotVersion }}


### PR DESCRIPTION
A GitHub actionnable workflow that can bump the stable vertx version and the stable snapshot vertx version

The workflow can be actioned from the Actions tab and requires to provide the stable version an the stable snapshot version, it uses JQ to replace the version in the starter.json configuration file and then push the commit to the branch.

<img width="442" alt="Screenshot 2024-10-16 at 17 36 28" src="https://github.com/user-attachments/assets/5adb6ab5-50f0-4014-a3c7-a4a9a6444104">

<img width="542" alt="Screenshot 2024-10-16 at 17 37 49" src="https://github.com/user-attachments/assets/35c36cfb-0a88-44f4-8e66-0e0abed169a6">

<img width="1547" alt="Screenshot 2024-10-16 at 17 33 44" src="https://github.com/user-attachments/assets/5a2ed8ce-7900-456c-b95f-1dd9f1599192">
