### PR TITLE
Vert.x 5 version change: 5.0.0.CR1

### DIFF
--- a/src/main/resources/starter.json
+++ b/src/main/resources/starter.json
@@ -22,7 +22,7 @@
       ]
     },
     {
-      "number": "5.0.0-SNAPSHOT",
+      "number": "5.0.0.CR1",
       "exclusions": [
         "vertx-web-openapi",
         "vertx-auth-shiro",

--- a/src/main/resources/templates/build.gradle.kts.ftl
+++ b/src/main/resources/templates/build.gradle.kts.ftl
@@ -1,7 +1,13 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 <#if language == "kotlin">
+<#if vertxVersion?starts_with("5.")>
+import org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode.IGNORE
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+<#else>
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+</#if>
 </#if>
 
 plugins {
@@ -82,6 +88,10 @@ dependencies {
 val compileKotlin: KotlinCompile by tasks
 <#if vertxVersion?starts_with("5.")>
 compileKotlin.kotlinOptions.jvmTarget = "${jdkVersion?switch('11', '11', '17' '17', '21' '21', '17')}"
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+  jvmTargetValidationMode.set(IGNORE)
+}
 <#else>
 compileKotlin.kotlinOptions.jvmTarget = "${jdkVersion?switch('11', '11', '17' '17', '17')}"
 </#if>


### PR DESCRIPTION
5.0.0.CR1 has been released and we should propose it instead of 5.0.0-SNAPSHOT