### PR TITLE
Use specific JDK for generator tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,10 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: |
+            11
+            21
+            17
       - name: Run other tests
         run: mvn test -P ${{ matrix.profile }}
   Deploy:


### PR DESCRIPTION
At the beginning of the test job, all target JDKs will be installed. The last JDK in the list is the JDK use to build the starter and run the test (Java 17).

In GeneratorTest, we can pick a JDK specific to the generated project target.