### PR TITLE
Add Scala to start.vertx.io

### DIFF
--- a/src/main/java/io/vertx/starter/model/Language.java
+++ b/src/main/java/io/vertx/starter/model/Language.java
@@ -25,7 +25,10 @@ public enum Language {
   JAVA("java", ".java"),
 
   @JsonProperty("kotlin")
-  KOTLIN("kotlin", ".kt", "vertx-lang-kotlin");
+  KOTLIN("kotlin", ".kt", "vertx-lang-kotlin"),
+
+  @JsonProperty("scala")
+  SCALA("scala", ".scala");
 
   private final String name;
   private final String extension;

--- a/src/main/resources/templates/build.gradle.kts.ftl
+++ b/src/main/resources/templates/build.gradle.kts.ftl
@@ -17,6 +17,8 @@ plugins {
 <#else>
   kotlin ("jvm") version "1.7.21"
 </#if>
+<#elseif language == "scala">
+  scala
 <#else>
   java
 </#if>
@@ -71,11 +73,18 @@ dependencies {
 </#list>
 <#if language == "kotlin" && vertxVersion?starts_with("4.")>
   implementation(kotlin("stdlib-jdk8"))
+<#elseif language == "scala">
+  implementation("org.scala-lang:scala3-library_3:3.5.2")
+  implementation("io.vertx:vertx-lang-scala_3:${vertxVersion}")
 </#if>
 <#if hasPgClient>
   implementation("com.ongres.scram:client:2.1")
 </#if>
-<#if hasVertxJUnit5>
+<#if language == "scala">
+  testImplementation("io.vertx:vertx-lang-scala-test_3:${vertxVersion}")
+  testImplementation("org.scalatest:scalatest_3:3.2.19")
+  testRuntimeOnly("org.scalatestplus:junit-5-11_3:3.2.19.0")
+<#elseif hasVertxJUnit5>
   testImplementation("io.vertx:vertx-junit5")
   testImplementation("org.junit.jupiter:junit-jupiter:$junitJupiterVersion")
 <#elseif hasVertxUnit>

--- a/src/main/resources/templates/pom.xml.ftl
+++ b/src/main/resources/templates/pom.xml.ftl
@@ -15,7 +15,8 @@
     <#if vertxVersion?starts_with("5.")>
     <kotlin.version>2.0.0</kotlin.version>
     <#else>
-    <kotlin.version>1.7.21</kotlin.version>
+      <kotlin.version>1.7.21</kotlin.version>
+    </#if>
     <#elseif language == "scala">
     <scala.version>3.5.2</scala.version>
     <#else>
@@ -81,13 +82,14 @@
       </dependency>
     </#noparse>
     <#else>
-    <#noparse>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-jdk8</artifactId>
-        <version>${kotlin.version}</version>
-      </dependency>
-    </#noparse>
+      <#noparse>
+        <dependency>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-jdk8</artifactId>
+          <version>${kotlin.version}</version>
+        </dependency>
+      </#noparse>
+    </#if>
     <#elseif language == "scala">
       <#noparse>
         <dependency>
@@ -111,18 +113,20 @@
     </#if>
 
     <#if language == "scala">
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-lang-scala-test_3</artifactId>
-      <version>${vertx.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_3</artifactId>
-      <version>3.2.17</version>
-      <scope>test</scope>
-    </dependency>
+    <#noparse>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-lang-scala-test_3</artifactId>
+        <version>${vertx.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest_3</artifactId>
+        <version>3.2.19</version>
+        <scope>test</scope>
+      </dependency>
+    </#noparse>
     <#elseif hasVertxJUnit5>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -206,10 +210,9 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>4.8.1</version>
+        <version>4.9.2</version>
         <configuration>
           <args>
-            <arg>java-output-version 8</arg>
             <arg>-feature</arg>
             <arg>-deprecation</arg>
           </args>

--- a/src/main/resources/templates/pom.xml.ftl
+++ b/src/main/resources/templates/pom.xml.ftl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>${groupId}</groupId>
@@ -11,31 +11,31 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-<#if language == "kotlin">
-<#if vertxVersion?starts_with("5.")>
+    <#if language == "kotlin">
+    <#if vertxVersion?starts_with("5.")>
     <kotlin.version>2.0.0</kotlin.version>
-<#else>
+    <#else>
     <kotlin.version>1.7.21</kotlin.version>
-</#if>
-
-<#else>
-    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-</#if>
+    <#elseif language == "scala">
+    <scala.version>3.5.2</scala.version>
+    <#else>
+      <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    </#if>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
 
     <vertx.version>${vertxVersion}</vertx.version>
-<#if hasVertxJUnit5>
-    <junit-jupiter.version>5.9.1</junit-jupiter.version>
-</#if>
+    <#if hasVertxJUnit5>
+      <junit-jupiter.version>5.9.1</junit-jupiter.version>
+    </#if>
 
     <main.verticle>${packageName}.MainVerticle</main.verticle>
-<#if vertxVersion?starts_with("5.")>
+    <#if vertxVersion?starts_with("5.")>
     <launcher.class>io.vertx.launcher.application.VertxApplication</launcher.class>
-<#else>
-    <launcher.class>io.vertx.core.Launcher</launcher.class>
-</#if>
+    <#else>
+      <launcher.class>io.vertx.core.Launcher</launcher.class>
+    </#if>
   </properties>
 
   <dependencyManagement>
@@ -43,9 +43,9 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-<#noparse>
-        <version>${vertx.version}</version>
-</#noparse>
+        <#noparse>
+          <version>${vertx.version}</version>
+        </#noparse>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -53,52 +53,77 @@
   </dependencyManagement>
 
   <dependencies>
-<#if !vertxDependencies?has_content>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-core</artifactId>
-    </dependency>
-</#if>
-<#if vertxVersion?starts_with("5.")>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-launcher-application</artifactId>
-    </dependency>
-</#if>
-<#list vertxDependencies as dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>${dependency}</artifactId>
-    </dependency>
-</#list>
-<#if language == "kotlin">
-<#if vertxVersion?starts_with("5.")>
-<#noparse>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>${kotlin.version}</version>
-    </dependency>
-</#noparse>
-<#else>
-<#noparse>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jdk8</artifactId>
-      <version>${kotlin.version}</version>
-    </dependency>
-</#noparse>
-</#if>
-</#if>
-<#if hasPgClient>
-    <dependency>
-      <groupId>com.ongres.scram</groupId>
-      <artifactId>client</artifactId>
-      <version>2.1</version>
-    </dependency>
-</#if>
+    <#if !vertxDependencies?has_content>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-core</artifactId>
+      </dependency>
+    </#if>
+    <#if vertxVersion?starts_with("5.")>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-launcher-application</artifactId>
+      </dependency>
+    </#if>
+    <#list vertxDependencies as dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>${dependency}</artifactId>
+      </dependency>
+    </#list>
+    <#if language == "kotlin">
+    <#if vertxVersion?starts_with("5.")>
+    <#noparse>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+    </#noparse>
+    <#else>
+    <#noparse>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+    </#noparse>
+    <#elseif language == "scala">
+      <#noparse>
+        <dependency>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala3-library_3</artifactId>
+          <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-lang-scala_3</artifactId>
+          <version>${vertx.version}</version>
+        </dependency>
+      </#noparse>
+    </#if>
+    <#if hasPgClient>
+      <dependency>
+        <groupId>com.ongres.scram</groupId>
+        <artifactId>client</artifactId>
+        <version>2.1</version>
+      </dependency>
+    </#if>
 
-<#if hasVertxJUnit5>
+    <#if language == "scala">
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-scala-test_3</artifactId>
+      <version>${vertx.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_3</artifactId>
+      <version>3.2.17</version>
+      <scope>test</scope>
+    </dependency>
+    <#elseif hasVertxJUnit5>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
@@ -107,55 +132,60 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-<#noparse>
-      <version>${junit-jupiter.version}</version>
-</#noparse>
+      <#noparse>
+        <version>${junit-jupiter.version}</version>
+      </#noparse>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-<#noparse>
-      <version>${junit-jupiter.version}</version>
-</#noparse>
+      <#noparse>
+        <version>${junit-jupiter.version}</version>
+      </#noparse>
       <scope>test</scope>
     </dependency>
-<#elseif hasVertxUnit>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
-</#if>
+    <#elseif hasVertxUnit>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-unit</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+        <scope>test</scope>
+      </dependency>
+    </#if>
   </dependencies>
 
   <build>
-<#if language == "kotlin">
-<#noparse>
+    <#if language == "kotlin">
+    <#noparse>
       <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
       <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
-</#noparse>
-</#if>
+    </#noparse>
+    <#elseif language == "scala">
+      <#noparse>
+        <sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/scala</testSourceDirectory>
+      </#noparse>
+    </#if>
     <plugins>
-<#if language == "kotlin">
+      <#if language == "kotlin">
       <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
-<#noparse>
-        <version>${kotlin.version}</version>
-</#noparse>
+        <#noparse>
+          <version>${kotlin.version}</version>
+        </#noparse>
         <configuration>
-<#if vertxVersion?starts_with("5.")>
+          <#if vertxVersion?starts_with("5.")>
           <jvmTarget>${jdkVersion?switch('11', '11', '17' '17', '21' '21', '17')}</jvmTarget>
-<#else>
-          <jvmTarget>${jdkVersion?switch('11', '11', '17' '17', '17')}</jvmTarget>
-</#if>
+          <#else>
+            <jvmTarget>${jdkVersion?switch('11', '11', '17' '17', '17')}</jvmTarget>
+          </#if>
         </configuration>
         <executions>
           <execution>
@@ -172,22 +202,69 @@
           </execution>
         </executions>
       </plugin>
-<#else>
+      <#elseif language == "scala">
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-<#noparse>
-        <version>${maven-compiler-plugin.version}</version>
-</#noparse>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>4.8.1</version>
         <configuration>
-          <release>${jdkVersion}</release>
+          <args>
+            <arg>java-output-version 8</arg>
+            <arg>-feature</arg>
+            <arg>-deprecation</arg>
+          </args>
         </configuration>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
-</#if>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <version>2.2.0</version>
+        <configuration>
+          <#noparse>
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+          </#noparse>
+          <junitxml>.</junitxml>
+          <filereports>WDF TestSuite.txt</filereports>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <#else>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <#noparse>
+            <version>${maven-compiler-plugin.version}</version>
+          </#noparse>
+          <configuration>
+            <release>${jdkVersion}</release>
+          </configuration>
+        </plugin>
+      </#if>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-<#noparse>
-        <version>${maven-shade-plugin.version}</version>
-</#noparse>
+        <#noparse>
+          <version>${maven-shade-plugin.version}</version>
+        </#noparse>
         <executions>
           <execution>
             <phase>package</phase>
@@ -199,17 +276,18 @@
                 <transformer
                   implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
-<#noparse>
-                    <Main-Class>${launcher.class}</Main-Class>
-                    <Main-Verticle>${main.verticle}</Main-Verticle>
-</#noparse>
+                    <#noparse>
+                      <Main-Class>${launcher.class}</Main-Class>
+                      <Main-Verticle>${main.verticle}</Main-Verticle>
+                    </#noparse>
                   </manifestEntries>
                 </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               </transformers>
-<#noparse>
-              <outputFile>${project.build.directory}/${project.artifactId}-${project.version}-fat.jar
-</#noparse>
+              <#noparse>
+                <outputFile>${project.build.directory}/${project.artifactId}-${project.version}-fat.jar
+              </#noparse>
               </outputFile>
             </configuration>
           </execution>
@@ -217,50 +295,55 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-<#noparse>
-        <version>${maven-surefire-plugin.version}</version>
-</#noparse>
+        <#noparse>
+          <version>${maven-surefire-plugin.version}</version>
+        </#noparse>
+        <#if language == "scala">
+          <configuration>
+            <skipTests>true</skipTests>
+          </configuration>
+        </#if>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-<#noparse>
-        <version>${exec-maven-plugin.version}</version>
-</#noparse>
+        <#noparse>
+          <version>${exec-maven-plugin.version}</version>
+        </#noparse>
         <configuration>
-<#noparse>
-          <mainClass>${launcher.class}</mainClass>
-</#noparse>
+          <#noparse>
+            <mainClass>${launcher.class}</mainClass>
+          </#noparse>
           <arguments>
-<#if vertxVersion?starts_with("4.")>
-            <argument>run</argument>
-</#if>
-<#noparse>
-            <argument>${main.verticle}</argument>
-</#noparse>
+            <#if vertxVersion?starts_with("4.")>
+              <argument>run</argument>
+            </#if>
+            <#noparse>
+              <argument>${main.verticle}</argument>
+            </#noparse>
           </arguments>
         </configuration>
       </plugin>
     </plugins>
   </build>
 
-<#if vertxVersion?ends_with("-SNAPSHOT")>
-  <repositories>
-    <repository>
-      <id>sonatype-oss-snapshots</id>
-      <name>Sonatype OSSRH Snapshots</name>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-      <layout>default</layout>
-      <releases>
-        <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </snapshots>
-    </repository>
-  </repositories>
-</#if>
+  <#if vertxVersion?ends_with("-SNAPSHOT")>
+    <repositories>
+      <repository>
+        <id>sonatype-oss-snapshots</id>
+        <name>Sonatype OSSRH Snapshots</name>
+        <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        <layout>default</layout>
+        <releases>
+          <enabled>false</enabled>
+          <updatePolicy>never</updatePolicy>
+        </releases>
+        <snapshots>
+          <enabled>true</enabled>
+          <updatePolicy>never</updatePolicy>
+        </snapshots>
+      </repository>
+    </repositories>
+  </#if>
 
 </project>

--- a/src/main/resources/templates/src/main/scala/MainVerticle.scala.ftl
+++ b/src/main/resources/templates/src/main/scala/MainVerticle.scala.ftl
@@ -1,0 +1,28 @@
+package ${packageName}
+
+import io.vertx.core.{AbstractVerticle, Promise}
+import io.vertx.lang.scala.ScalaVerticle
+import io.vertx.lang.scala.ImplicitConversions.vertxFutureToScalaFuture
+
+import scala.concurrent.Future
+import scala.language.implicitConversions
+
+class MainVerticle extends AbstractVerticle:
+
+  override def start(startPromise: Promise[Void]): Unit =
+    vertx
+      .deployVerticle(HttpVerticle().asJava)
+      .onSuccess(_ => startPromise.complete)
+      .onFailure(e => startPromise.fail(e))
+
+
+class HttpVerticle extends ScalaVerticle:
+
+  override def asyncStart: Future[Unit] =
+    vertx
+      .createHttpServer()
+      .requestHandler(_.response
+        .putHeader("content-type", "text/plain")
+        .end("Hello from Vert.x!"))
+      .listen(8888)
+      .mapEmpty[Unit]()

--- a/src/main/resources/templates/src/test/scala/TestMainVerticle.scala.ftl
+++ b/src/main/resources/templates/src/test/scala/TestMainVerticle.scala.ftl
@@ -1,0 +1,24 @@
+package ${packageName}
+
+import io.vertx.core.http.HttpMethod
+
+import io.vertx.lang.scala.ImplicitConversions.vertxFutureToScalaFuture
+import io.vertx.lang.scala.testing.VerticleTesting
+
+import org.scalatest.matchers.should.Matchers
+
+import scala.language.implicitConversions
+
+
+class HttpVerticleSpec extends VerticleTesting[HttpVerticle], Matchers:
+
+  "HttpVerticle" should "bind to 8888 and answer with 'Hello from Vert.x!'" in {
+    val httpClient = vertx.createHttpClient()
+
+    for {
+      req  <- httpClient.request(HttpMethod.GET, 8888, "127.0.0.1", "/")
+      res  <- req.send()
+      body <- res.body.map(_.toString)
+      assertion = body should equal("Hello from Vert.x!")
+    } yield assertion
+  }


### PR DESCRIPTION
Motivation:

Now that we have `vertx-lang-scala` in Maven Central, we could offer it via [start.vertx.io](https://start.vertx.io)!

This PR adds
  - the Scala template files
  - a Maven template
  - a Gradle template

> Please note that we have not yet deployed any `5.x` version to Maven Central!
