### PR TITLE
Add Scala to start.vertx.io

### DIFF
--- a/src/main/java/io/vertx/starter/model/Language.java
+++ b/src/main/java/io/vertx/starter/model/Language.java
@@ -25,7 +25,10 @@ public enum Language {
   JAVA("java", ".java"),
 
   @JsonProperty("kotlin")
-  KOTLIN("kotlin", ".kt", "vertx-lang-kotlin");
+  KOTLIN("kotlin", ".kt", "vertx-lang-kotlin"),
+
+  @JsonProperty("scala")
+  SCALA("scala", ".scala");
 
   private final String name;
   private final String extension;

--- a/src/main/resources/templates/build.gradle.kts.ftl
+++ b/src/main/resources/templates/build.gradle.kts.ftl
@@ -17,6 +17,8 @@ plugins {
 <#else>
   kotlin ("jvm") version "1.7.21"
 </#if>
+<#elseif language == "scala">
+  scala
 <#else>
   java
 </#if>
@@ -71,11 +73,18 @@ dependencies {
 </#list>
 <#if language == "kotlin" && vertxVersion?starts_with("4.")>
   implementation(kotlin("stdlib-jdk8"))
+<#elseif language == "scala">
+  implementation("org.scala-lang:scala3-library_3:3.5.2")
+  implementation("io.vertx:vertx-lang-scala_3:${vertxVersion}")
 </#if>
 <#if hasPgClient>
   implementation("com.ongres.scram:client:2.1")
 </#if>
-<#if hasVertxJUnit5>
+<#if language == "scala">
+  testImplementation("io.vertx:vertx-lang-scala-test_3:${vertxVersion}")
+  testImplementation("org.scalatest:scalatest_3:3.2.19")
+  testRuntimeOnly("org.scalatestplus:junit-5-11_3:3.2.19.0")
+<#elseif hasVertxJUnit5>
   testImplementation("io.vertx:vertx-junit5")
   testImplementation("org.junit.jupiter:junit-jupiter:$junitJupiterVersion")
 <#elseif hasVertxUnit>

--- a/src/main/resources/templates/pom.xml.ftl
+++ b/src/main/resources/templates/pom.xml.ftl
@@ -18,6 +18,9 @@
     <kotlin.version>1.7.21</kotlin.version>
 </#if>
 
+<#elseif language == "scala">
+    <scala.version>3.5.2</scala.version>
+    <scalatest.version>3.2.19</scalatest.version>
 <#else>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 </#if>
@@ -89,6 +92,20 @@
     </dependency>
 </#noparse>
 </#if>
+
+<#elseif language == "scala">
+<#noparse>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala3-library_3</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-scala_3</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+</#noparse>
 </#if>
 <#if hasPgClient>
     <dependency>
@@ -98,7 +115,22 @@
     </dependency>
 </#if>
 
-<#if hasVertxJUnit5>
+<#if language == "scala">
+<#noparse>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-scala-test_3</artifactId>
+      <version>${vertx.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_3</artifactId>
+      <version>${scalatest.version}</version>
+      <scope>test</scope>
+    </dependency>
+</#noparse>
+<#elseif hasVertxJUnit5>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
@@ -141,6 +173,11 @@
       <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
       <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
 </#noparse>
+<#elseif language == "scala">
+<#noparse>
+      <sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>
+      <testSourceDirectory>${project.basedir}/src/test/scala</testSourceDirectory>
+</#noparse>
 </#if>
     <plugins>
 <#if language == "kotlin">
@@ -168,6 +205,52 @@
             <id>test-compile</id>
             <goals>
               <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+<#elseif language == "scala">
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>4.9.2</version>
+        <configuration>
+          <args>
+            <arg>-feature</arg>
+            <arg>-deprecation</arg>
+          </args>
+        </configuration>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <version>2.2.0</version>
+        <configuration>
+<#noparse>
+          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+</#noparse>
+          <junitxml>.</junitxml>
+          <filereports>WDF TestSuite.txt</filereports>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
             </goals>
           </execution>
         </executions>
@@ -220,6 +303,11 @@
 <#noparse>
         <version>${maven-surefire-plugin.version}</version>
 </#noparse>
+<#if language == "scala">
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+</#if>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/src/main/resources/templates/src/main/scala/MainVerticle.scala.ftl
+++ b/src/main/resources/templates/src/main/scala/MainVerticle.scala.ftl
@@ -1,0 +1,28 @@
+package ${packageName}
+
+import io.vertx.core.{AbstractVerticle, Promise}
+import io.vertx.lang.scala.ScalaVerticle
+import io.vertx.lang.scala.ImplicitConversions.vertxFutureToScalaFuture
+
+import scala.concurrent.Future
+import scala.language.implicitConversions
+
+class MainVerticle extends AbstractVerticle:
+
+  override def start(startPromise: Promise[Void]): Unit =
+    vertx
+      .deployVerticle(HttpVerticle().asJava)
+      .onSuccess(_ => startPromise.complete)
+      .onFailure(e => startPromise.fail(e))
+
+
+class HttpVerticle extends ScalaVerticle:
+
+  override def asyncStart: Future[Unit] =
+    vertx
+      .createHttpServer()
+      .requestHandler(_.response
+        .putHeader("content-type", "text/plain")
+        .end("Hello from Vert.x!"))
+      .listen(8888)
+      .mapEmpty[Unit]()

--- a/src/main/resources/templates/src/test/scala/TestMainVerticle.scala.ftl
+++ b/src/main/resources/templates/src/test/scala/TestMainVerticle.scala.ftl
@@ -1,0 +1,24 @@
+package ${packageName}
+
+import io.vertx.core.http.HttpMethod
+
+import io.vertx.lang.scala.ImplicitConversions.vertxFutureToScalaFuture
+import io.vertx.lang.scala.testing.VerticleTesting
+
+import org.scalatest.matchers.should.Matchers
+
+import scala.language.implicitConversions
+
+
+class MainVerticleSpec extends VerticleTesting[HttpVerticle], Matchers:
+
+  "HttpVerticle" should "bind to 8888 and answer with 'Hello from Vert.x!'" in {
+    val httpClient = vertx.createHttpClient()
+
+    for {
+      req  <- httpClient.request(HttpMethod.GET, 8888, "127.0.0.1", "/")
+      res  <- req.send()
+      body <- res.body.map(_.toString)
+      assertion = body should equal("Hello from Vert.x!")
+    } yield assertion
+  }


### PR DESCRIPTION
**Motivation:**

Now that we have `vertx-lang-scala` in Maven Central, we could offer it via [start.vertx.io](https://start.vertx.io/)!

This is a follow-up from PR #624. It fixes the formatting changes I did back then. 

**This PR adds**

the Scala template files
a Maven template
a Gradle template