### PR TITLE
Don't include unused variables for Vert.x 5

### DIFF
--- a/src/main/resources/templates/build.gradle.kts.ftl
+++ b/src/main/resources/templates/build.gradle.kts.ftl
@@ -47,12 +47,12 @@ val mainVerticleName = "${packageName}.MainVerticle"
 val launcherClassName = "io.vertx.launcher.application.VertxApplication"
 <#else>
 val launcherClassName = "io.vertx.core.Launcher"
-</#if>
 
 val watchForChange = "src/**/*"
 <#noparse>
 val doOnChange = "${projectDir}/gradlew classes"
 </#noparse>
+</#if>
 
 application {
   mainClass.set(launcherClassName)


### PR DESCRIPTION
`watchForChange` and `doOnChange` are only used for the Vert.x 4 launcher.