### PR TITLE
Update scram dependency for v5 PgClient

### DIFF
--- a/src/main/resources/templates/pom.xml.ftl
+++ b/src/main/resources/templates/pom.xml.ftl
@@ -91,11 +91,19 @@
 </#if>
 </#if>
 <#if hasPgClient>
-    <dependency>
-      <groupId>com.ongres.scram</groupId>
-      <artifactId>client</artifactId>
-      <version>2.1</version>
-    </dependency>
+<#if vertxVersion?starts_with("5.")>
+  <dependency>
+    <groupId>com.ongres.scram</groupId>
+    <artifactId>scram-client</artifactId>
+    <version>3.1</version>
+  </dependency>
+<#else>
+  <dependency>
+  <groupId>com.ongres.scram</groupId>
+  <artifactId>client</artifactId>
+  <version>2.1</version>
+  </dependency>
+</#if>
 </#if>
 
 <#if hasVertxJUnit5>


### PR DESCRIPTION
Motivation:

v5 PgClient depends on the updated com.ongres library (com.ongres.scram:scram-client:3.1) in this PR

Conformance:

My ECA is up to date. I haven't signed this very small change but I'll generate a key and resubmit if necessary.