### PR TITLE
Ongres Scram client dependency is only required by Vert.x 4

### DIFF
--- a/src/main/resources/templates/build.gradle.kts.ftl
+++ b/src/main/resources/templates/build.gradle.kts.ftl
@@ -72,7 +72,7 @@ dependencies {
 <#if language == "kotlin" && vertxVersion?starts_with("4.")>
   implementation(kotlin("stdlib-jdk8"))
 </#if>
-<#if hasPgClient>
+<#if hasPgClient && vertxVersion?starts_with("4.")>
   implementation("com.ongres.scram:client:2.1")
 </#if>
 <#if hasVertxJUnit5>

--- a/src/main/resources/templates/pom.xml.ftl
+++ b/src/main/resources/templates/pom.xml.ftl
@@ -90,20 +90,12 @@
 </#noparse>
 </#if>
 </#if>
-<#if hasPgClient>
-<#if vertxVersion?starts_with("5.")>
+<#if hasPgClient && vertxVersion?starts_with("4.")>
   <dependency>
     <groupId>com.ongres.scram</groupId>
-    <artifactId>scram-client</artifactId>
-    <version>3.1</version>
+    <artifactId>client</artifactId>
+    <version>2.1</version>
   </dependency>
-<#else>
-  <dependency>
-  <groupId>com.ongres.scram</groupId>
-  <artifactId>client</artifactId>
-  <version>2.1</version>
-  </dependency>
-</#if>
 </#if>
 
 <#if hasVertxJUnit5>


### PR DESCRIPTION
In Vert.x 5, the dependency is transitive.

See https://github.com/eclipse-vertx/vertx-sql-client/pull/1481