### PR TITLE
Update GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
         profile: [ generator-tests-jdk17,generator-tests-jdk21,generator-tests-jdk25,no-generator-tests ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,16 +10,17 @@ jobs:
     name: Deploy to starter machine
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 25
       - name: Setup SSH
-        uses: kielabokkie/ssh-key-and-known-hosts-action@v1
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-host: 13.94.149.21
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H 13.94.149.21 >> ~/.ssh/known_hosts
       - name: Assemble
         run: mvn package -DskipTests
       - name: Run deployment script

--- a/.github/workflows/set-versions.yml
+++ b/.github/workflows/set-versions.yml
@@ -22,18 +22,14 @@ jobs:
         profile: [ generator-tests-jdk17,generator-tests-jdk21,generator-tests-jdk25,no-generator-tests ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: |
             17
             21
             25
-      - uses: dcarbone/install-jq-action@v2
-        with:
-          version: '1.7'
-          force: true
       - name: Set versions
         run: bash .gh.set-versions.bash $OLD_STABLE_VERSION $CURRENT_STABLE_VERSION $SNAPSHOT_VERSION
         env:
@@ -46,11 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: dcarbone/install-jq-action@v2
-        with:
-          version: '1.7'
-          force: true
+        uses: actions/checkout@v6
       - name: Set versions
         run: bash .gh.set-versions.bash $OLD_STABLE_VERSION $CURRENT_STABLE_VERSION $SNAPSHOT_VERSION
         env:


### PR DESCRIPTION
actions/checkout@v4 and actions/setup-java@v4 are running on Node.js 20, that goes away later this year

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Also, got rid of marketplace actions:

- setup SSH manually
- jq comes pre-installed on all runners