### PR TITLE
Force checkout of the latest prod branch head in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: prod
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'


### PR DESCRIPTION
When this workflow is invoked from ci.yml on push to the prod branch, the checkout action uses the HEAD commit SHA for reference. When invoked from set-versions.yml, it uses the commit SHA that triggerred the workflow call, which is not the commit we want to use for deployment. We want to use the latest commit that we pushed as part of the worflow.

Consequently, it seems best to configure checkout by using the prod branch reference. With this setting, we'll always use the latest commit from the prod branch, which works in both contexts.