### PR TITLE
Make commit SHA configurable in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,10 @@
 name: Deploy
 on:
   workflow_call:
+    inputs:
+      sha:
+        required: false
+        type: string
     secrets:
       SSH_PRIVATE_KEY:
         required: true
@@ -12,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: prod
+          ref: ${{ inputs.sha || github.sha }}
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'

--- a/.github/workflows/set-versions.yml
+++ b/.github/workflows/set-versions.yml
@@ -40,6 +40,8 @@ jobs:
         run: mvn test -P ${{ matrix.profile }}
   Update-repo:
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.push.outputs.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -50,12 +52,14 @@ jobs:
           CURRENT_STABLE_VERSION: ${{ inputs.currentStableVersion }}
           SNAPSHOT_VERSION: ${{ inputs.snapshotVersion }}
       - name: Commit and push
+        id: push
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add src/main/resources/starter.json
           git commit -m "Update Vert.x versions to $OLD_STABLE_VERSION, $CURRENT_STABLE_VERSION and $SNAPSHOT_VERSION"
           git push
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         env:
           OLD_STABLE_VERSION: ${{ inputs.oldStableVersion }}
           CURRENT_STABLE_VERSION: ${{ inputs.currentStableVersion }}
@@ -65,5 +69,7 @@ jobs:
     if: ${{ github.repository_owner == 'vert-x3' && github.ref == 'refs/heads/prod' }}
     needs: [Test, Update-repo]
     uses: ./.github/workflows/deploy.yml
+    with:
+      sha: ${{ needs.Update-repo.outputs.sha }}
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Follows-up on https://github.com/vert-x3/vertx-starter/pull/873

The previous PR did not succeed to fix the problem of the commit SHA determined by GitHub on workflow call. In this attempt, the commit sha is provided to the deploy.yml workflow as an input.

Some portions of this content were created with the assistance of Claude Code